### PR TITLE
Removing custom_decorator and moving to Tornado 6 support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 	@find . -name "*.pyc" -delete
 
 test: clean
-	nosetests -s --tests=tests/ --with-xunit
+	pytest -s tests/ --junit-xml=junit.xml
 
 release:
 	python setup.py sdist register upload

--- a/README.md
+++ b/README.md
@@ -56,25 +56,6 @@ class MyHandler(CorsMixin, RequestHandler):
     ...
 ```
 
-Advanced
---------
-
-By default, CorsMixin defines "options" method using the decorator
-"asynchronous" from "tornado.web".
-
-If your project customizes this decorator for some purpose (eg. usage of
-greenlets), CorsMixin allows such customization in options wrapper.
-
-Usage:
-
-```
-# custom_wrapper was previously defined
-
-from tornado_cors import custom_decorator
-custom_decorator.wrapper = custom_wrapper
-
-```
-
 
 ## License
 

--- a/requirements.local.txt
+++ b/requirements.local.txt
@@ -1,1 +1,1 @@
-nose
+pytest

--- a/tests/test_tornado_cors.py
+++ b/tests/test_tornado_cors.py
@@ -23,7 +23,7 @@ def custom_wrapper(method):
 class CorsTestCase(AsyncHTTPTestCase):
 
     def test_should_return_headers_with_default_values_in_options_request(self):
-        response = self.fetch('/default', self.stop, method='OPTIONS')
+        response = self.fetch('/default', method='OPTIONS')
         headers = response.headers
 
         self.assertNotIn('Access-Control-Allow-Origin', headers)
@@ -34,7 +34,7 @@ class CorsTestCase(AsyncHTTPTestCase):
         self.assertEqual(headers['Access-Control-Max-Age'], '86400')
 
     def test_should_return_headers_with_custom_values_in_options_request(self):
-        response = self.fetch('/custom', self.stop, method='OPTIONS')
+        response = self.fetch('/custom', method='OPTIONS')
         headers = response.headers
         self.assertEqual(headers['Access-Control-Allow-Origin'], '*')
         self.assertEqual(headers['Access-Control-Allow-Headers'], 'Content-Type')
@@ -44,13 +44,13 @@ class CorsTestCase(AsyncHTTPTestCase):
         self.assertNotIn('Access-Control-Max-Age', headers)
 
     def test_should_return_headers_for_requests_other_than_options(self):
-        response = self.fetch('/custom', self.stop, method='POST', body='')
+        response = self.fetch('/custom', method='POST', body='')
         headers = response.headers
         self.assertEqual(headers['Access-Control-Allow-Origin'], '*')
         self.assertEqual(headers['Access-Control-Expose-Headers'], 'Location')
 
     def test_should_support_custom_methods(self):
-        response = self.fetch('/custom_method', self.stop, method='OPTIONS')
+        response = self.fetch('/custom_method', method='OPTIONS')
         headers = response.headers
         self.assertEqual(headers["Access-Control-Allow-Methods"], 'OPTIONS, NEW_METHOD')
 

--- a/tornado_cors/__init__.py
+++ b/tornado_cors/__init__.py
@@ -4,12 +4,12 @@
 import inspect
 
 from tornado.web import RequestHandler
-from tornado_cors import custom_decorator
 
 
 def _get_class_that_defined_method(meth):
     for cls in inspect.getmro(meth.__self__.__class__):
-        if meth.__name__ in cls.__dict__: return cls
+        if meth.__name__ in cls.__dict__:
+            return cls
     return None
 
 
@@ -29,17 +29,17 @@ class CorsMixin(object):
         if self.CORS_EXPOSE_HEADERS:
             self.set_header('Access-Control-Expose-Headers', self.CORS_EXPOSE_HEADERS)
 
-    @custom_decorator.wrapper
-    def options(self, *args, **kwargs):
+    async def options(self, *args, **kwargs):
         if self.CORS_HEADERS:
             self.set_header('Access-Control-Allow-Headers', self.CORS_HEADERS)
         if self.CORS_METHODS:
             self.set_header('Access-Control-Allow-Methods', self.CORS_METHODS)
         else:
             self.set_header('Access-Control-Allow-Methods', self._get_methods())
-        if self.CORS_CREDENTIALS != None:
-            self.set_header('Access-Control-Allow-Credentials',
-                "true" if self.CORS_CREDENTIALS else "false")
+        if self.CORS_CREDENTIALS is not None:
+            self.set_header(
+                'Access-Control-Allow-Credentials', "true"
+                if self.CORS_CREDENTIALS else "false")
         if self.CORS_MAX_AGE:
             self.set_header('Access-Control-Max-Age', self.CORS_MAX_AGE)
 
@@ -58,7 +58,7 @@ class CorsMixin(object):
             if not meth:
                 continue
             handler_class = _get_class_that_defined_method(instance_meth)
-            if not handler_class is RequestHandler:
+            if handler_class is not RequestHandler:
                 methods.append(meth.upper())
 
         return ", ".join(methods)

--- a/tornado_cors/custom_decorator.py
+++ b/tornado_cors/custom_decorator.py
@@ -1,1 +1,0 @@
-from tornado.web import asynchronous as wrapper


### PR DESCRIPTION
What it says on the tin. Since `asynchronous` behavior is now provided by the `async` keyword in Python 3.6+, I went ahead and removed the wrapper -- if someone wanted to customize the `options` handler, there are other ways they can do that which may be better considering the new `async` process anyway.

It's worth re-iterating that these changes remove support for older versions of Python (e.g. 3.5, etc.)