### PR TITLE
Use Project-Specific CircleCI Context for PyPI Publish Credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,4 +76,4 @@ workflows:
               only: /^v[0-9]+(\.[0-9]+)*.*/
             branches:
               ignore: /.*/
-          context: org-global
+          context: ustudio-tornado-cors-publisher


### PR DESCRIPTION
This PR updates the CircleCI config to use a project-specific context publishing releases to PyPI, so that managing the credentials is easier.

Note that we will not be releasing a new version of the package because the code has not changed.

@ustudio/reviewers Please review